### PR TITLE
Fix: Correct badge URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A powerful, lightweight, browser-based Markdown editor designed for simplicity, privacy, and productivity.
 
-[![License](https://img.shields.io/github/license/tobiasbrendler/markdown-editor-pro)](https://github.com/tobiasbrendler/markdown-editor-pro/blob/main/LICENSE)
-[![Version](https://img.shields.io/github/package-json/v/tobiasbrendler/markdown-editor-pro)](https://github.com/tobiasbrendler/markdown-editor-pro)
+[![License](https://img.shields.io/github/license/Etschmia/mark)](https://github.com/Etschmia/mark/blob/main/LICENSE)
+[![Version](https://img.shields.io/github/package-json/v/Etschmia/mark)](https://github.com/Etschmia/mark)
 
 ## 🌟 Features
 


### PR DESCRIPTION
The license and version badges in the README.md were pointing to an incorrect repository, causing them to display as "repo not found".

This change updates the URLs to point to the correct repository, `Etschmia/mark`.